### PR TITLE
Fix Autograd for 1D

### DIFF
--- a/pytorch_fft/fft/autograd.py
+++ b/pytorch_fft/fft/autograd.py
@@ -7,10 +7,8 @@ class Fft(torch.autograd.Function):
         return fft(X_re, X_im)
 
     def backward(self, grad_output_re, grad_output_im):
-        N = grad_output_re.size(-1)
-        gr, gi = ifft(grad_output_re,-grad_output_im)
-        gr, gi = gr * N, -gi * N
-        return gr,gi
+        gr, gi = fft(grad_output_re, -grad_output_im)
+        return gr, -gi
 
 
 class Ifft(torch.autograd.Function):
@@ -19,9 +17,8 @@ class Ifft(torch.autograd.Function):
         return ifft(k_re, k_im)
 
     def backward(self, grad_output_re, grad_output_im):
-        gr, gi = fft(grad_output_re,-grad_output_im)
-        gr, gi = gr, -gi
-        return gr, gi
+        gr, gi = ifft(grad_output_re, -grad_output_im)
+        return gr, -gi
 
 
 class Fft2d(torch.autograd.Function):


### PR DESCRIPTION
This passes the test in #4.
The equation is derived from https://en.wikipedia.org/wiki/Wirtinger_derivatives.
I think the gradient should be multiplied by 2 because of the factor 1/2 in the Wirtinger equation, but multiplied gradient didn't match with the gradient by tf.fft. I don't know why.

---

PR #7 is made just an hour earlier than this commit. still making this PR for the discussion. Please use #7 because this PR only fixes the 1D case.

I think whether to view your two vectors `re` and `im` as (1) separate two variables or (2) real and image part of one complex variable is one's taste.

The questions are
- if optimizing two independent variables `re` and `im` in (1) is the same as
     optimizing one complex variable `re + i*im` in (2)

- Is #7 the same as this. If same, #7 might be faster because it doesn't contain the negation.
