### PR TITLE
Add Autograd functions Rfft{,2d,3d} and Irfft{,2d,3d}.

### DIFF
--- a/pytorch_fft/fft/autograd.py
+++ b/pytorch_fft/fft/autograd.py
@@ -1,8 +1,14 @@
 import torch
-from .fft import fft,ifft,fft2,ifft2,fft3,ifft3
+from .fft import fft,ifft,fft2,ifft2,fft3,ifft3,rfft,irfft,rfft2,irfft2,rfft3,irfft3
 
 def make_contiguous(*Xs):
     return tuple(X if X.is_contiguous() else X.contiguous() for X in Xs)
+
+def contiguous_clone(X):
+    if X.is_contiguous():
+        return X.clone()
+    else:
+        return X.contiguous()
 
 class Fft(torch.autograd.Function):
     def forward(self, X_re, X_im):
@@ -77,3 +83,142 @@ class Ifft3d(torch.autograd.Function):
                                                          grad_output_im)
         gi, gr = ifft3(grad_output_im,grad_output_re)
         return gr, gi
+
+
+class Rfft(torch.autograd.Function):
+    def forward(self, X_re):
+        X_re = X_re.contiguous()
+        self._to_save_input_size = X_re.size(-1)
+        return rfft(X_re)
+
+    def backward(self, grad_output_re, grad_output_im):
+        # Clone the array and make contiguous if needed
+        grad_output_re = contiguous_clone(grad_output_re)
+        grad_output_im = contiguous_clone(grad_output_im)
+
+        if self._to_save_input_size & 1:
+            grad_output_re[...,1:] /= 2
+        else:
+            grad_output_re[...,1:-1] /= 2
+
+        if self._to_save_input_size & 1:
+            grad_output_im[...,1:] /= 2
+        else:
+            grad_output_im[...,1:-1] /= 2
+
+        gr = irfft(grad_output_re,grad_output_im,self._to_save_input_size, normalize=False)
+        return gr
+
+
+class Irfft(torch.autograd.Function):
+
+    def forward(self, k_re, k_im):
+        k_re, k_im = make_contiguous(k_re, k_im)
+        return irfft(k_re, k_im)
+
+    def backward(self, grad_output_re):
+        grad_output_re = grad_output_re.contiguous()
+        gr, gi = rfft(grad_output_re)
+
+        N = grad_output_re.size(-1)
+        gr[...,0] /= N
+        gr[...,1:-1] /= N/2
+        gr[...,-1] /= N
+
+        gi[...,0] /= N
+        gi[...,1:-1] /= N/2
+        gi[...,-1] /= N
+        return gr, gi
+
+
+class Rfft2d(torch.autograd.Function):
+    def forward(self, X_re):
+        X_re = X_re.contiguous()
+        self._to_save_input_size = X_re.size(-1)
+        return rfft2(X_re)
+
+    def backward(self, grad_output_re, grad_output_im):
+        # Clone the array and make contiguous if needed
+        grad_output_re = contiguous_clone(grad_output_re)
+        grad_output_im = contiguous_clone(grad_output_im)
+
+        if self._to_save_input_size & 1:
+            grad_output_re[...,1:] /= 2
+        else:
+            grad_output_re[...,1:-1] /= 2
+
+        if self._to_save_input_size & 1:
+            grad_output_im[...,1:] /= 2
+        else:
+            grad_output_im[...,1:-1] /= 2
+
+        gr = irfft2(grad_output_re,grad_output_im,self._to_save_input_size, normalize=False)
+        return gr
+
+
+class Irfft2d(torch.autograd.Function):
+
+    def forward(self, k_re, k_im):
+        k_re, k_im = make_contiguous(k_re, k_im)
+        return irfft2(k_re, k_im)
+
+    def backward(self, grad_output_re):
+        grad_output_re = grad_output_re.contiguous()
+        gr, gi = rfft2(grad_output_re)
+
+        N = grad_output_re.size(-1) * grad_output_re.size(-2)
+        gr[...,0] /= N
+        gr[...,1:-1] /= N/2
+        gr[...,-1] /= N
+
+        gi[...,0] /= N
+        gi[...,1:-1] /= N/2
+        gi[...,-1] /= N
+        return gr, gi
+
+
+class Rfft3d(torch.autograd.Function):
+    def forward(self, X_re):
+        X_re = X_re.contiguous()
+        self._to_save_input_size = X_re.size(-1)
+        return rfft3(X_re)
+
+    def backward(self, grad_output_re, grad_output_im):
+        # Clone the array and make contiguous if needed
+        grad_output_re = contiguous_clone(grad_output_re)
+        grad_output_im = contiguous_clone(grad_output_im)
+
+        if self._to_save_input_size & 1:
+            grad_output_re[...,1:] /= 2
+        else:
+            grad_output_re[...,1:-1] /= 2
+
+        if self._to_save_input_size & 1:
+            grad_output_im[...,1:] /= 2
+        else:
+            grad_output_im[...,1:-1] /= 2
+
+        gr = irfft3(grad_output_re,grad_output_im,self._to_save_input_size, normalize=False)
+        return gr
+
+
+class Irfft3d(torch.autograd.Function):
+
+    def forward(self, k_re, k_im):
+        k_re, k_im = make_contiguous(k_re, k_im)
+        return irfft3(k_re, k_im)
+
+    def backward(self, grad_output_re):
+        grad_output_re = grad_output_re.contiguous()
+        gr, gi = rfft3(grad_output_re)
+
+        N = grad_output_re.size(-1) * grad_output_re.size(-2) * grad_output_re.size(-3)
+        gr[...,0] /= N
+        gr[...,1:-1] /= N/2
+        gr[...,-1] /= N
+
+        gi[...,0] /= N
+        gi[...,1:-1] /= N/2
+        gi[...,-1] /= N
+        return gr, gi
+

--- a/test.py
+++ b/test.py
@@ -71,6 +71,9 @@ def test_expand():
     assert np.allclose(cfft.expand(r1, odd=True).cpu().numpy(), c1.cpu().numpy())
     assert np.allclose(cfft.expand(r2, imag=True, odd=True).cpu().numpy(), c2.cpu().numpy())
 
+def create_real_var(*args):
+    return (torch.autograd.Variable(torch.randn(*args).double().cuda(), requires_grad=True),)
+
 def create_complex_var(*args):
     return (torch.autograd.Variable(torch.randn(*args).double().cuda(), requires_grad=True),
             torch.autograd.Variable(torch.randn(*args).double().cuda(), requires_grad=True))
@@ -98,6 +101,39 @@ def test_fft3d_gradcheck():
 def test_ifft3d_gradcheck():
     invar = create_complex_var(5,3,3,3)
     assert torch.autograd.gradcheck(afft.Ifft3d(), invar)
+
+def test_rfft_gradcheck():
+    invar = create_real_var(5,10)
+    assert torch.autograd.gradcheck(afft.Rfft(), invar)
+
+    invar = create_real_var(5,11)
+    assert torch.autograd.gradcheck(afft.Rfft(), invar)
+
+def test_rfft2d_gradcheck():
+    invar = create_real_var(5,6,6)
+    assert torch.autograd.gradcheck(afft.Rfft2d(), invar)
+
+    invar = create_real_var(5,5,5)
+    assert torch.autograd.gradcheck(afft.Rfft2d(), invar)
+
+def test_rfft3d_gradcheck():
+    invar = create_real_var(5,4,4,4)
+    assert torch.autograd.gradcheck(afft.Rfft3d(), invar)
+
+    invar = create_real_var(5,3,3,3)
+    assert torch.autograd.gradcheck(afft.Rfft3d(), invar)
+
+def test_irfft_gradcheck():
+    invar = create_complex_var(5,11)
+    assert torch.autograd.gradcheck(afft.Irfft(), invar)
+
+def test_irfft2d_gradcheck():
+    invar = create_complex_var(5,5,5)
+    assert torch.autograd.gradcheck(afft.Irfft2d(), invar)
+
+def test_irfft3d_gradcheck():
+    invar = create_complex_var(5,3,3,3)
+    assert torch.autograd.gradcheck(afft.Irfft3d(), invar)
 
 if __name__ == "__main__": 
     if torch.cuda.is_available():
@@ -130,5 +166,12 @@ if __name__ == "__main__":
         test_ifft2d_gradcheck()
         test_fft3d_gradcheck()
         test_ifft3d_gradcheck()
+
+        test_rfft_gradcheck()
+        test_irfft_gradcheck()
+        test_rfft2d_gradcheck()
+        test_irfft2d_gradcheck()
+        test_rfft3d_gradcheck()
+        test_irfft3d_gradcheck()
     else:
         print("Cuda not available, cannot test.")


### PR DESCRIPTION
Add Autograd functions Rfft{,2d,3d} and Irfft{,2d,3d}
I also added new test cases for those functions.

In order to write those functions, I also had to modify the prototype of the function irfft:
irrft now takes the output size as an extra optional argument. This is needed to get the correct output size in the backward pass of Rfft (for the case where the input size is odd).
I also added an extra option to disable the normalization which is useful to implement the backward pass of Rfft.